### PR TITLE
remove cname

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,4 +37,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/dirhtml
-        cname: ml4sts.com
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,4 +37,3 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./_build/dirhtml
-


### PR DESCRIPTION
a CNAME file tells a host what domain to work with; it's only part of the configuration, not the whole thing so this does not actually work and is not what we want for this site. This PR removes the setting that generates the file