### PR TITLE
fix quotes & make build succeed

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,6 +1,6 @@
 # -- Project information -----------------------------------------------------
 
-project = 'Jonathan's Title'
+project = "Jonathan's Title"
 copyright = '2022, Jonathan Lakavichit'
 author = 'Jonathan Lakavichit'
 


### PR DESCRIPTION
Your `conf.py` file had a typo in it that made it not build. 

the settings for sphinx are specified in python, which allows either `" "` or `' '` around strings, but if you want to use either `"` or `'` *in* your string, you have to surround it with the other.  Since you used an apostrophe, it thought that was the end fo the string, but then there were more characters it didn't know what to do with. 